### PR TITLE
Bump flickity version to 1.2.1 for newer features

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Enable sync for Flickity",
   "main": "flickity-sync.js",
   "dependencies": {
-    "flickity": "~1.0.0",
+    "flickity": "~1.2.1",
     "fizzy-ui-utils": "~1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enable sync for Flickity",
   "main": "flickity-sync.js",
   "dependencies": {
-    "flickity": "~1.0.0",
+    "flickity": "~1.2.1",
     "fizzy-ui-utils": "~1.0.0"
   },
   "scripts": {

--- a/test/index.html
+++ b/test/index.html
@@ -47,7 +47,6 @@
   <script src="../bower_components/flickity/js/animate.js"></script>
   <script src="../bower_components/flickity/js/flickity.js"></script>
   <script src="../bower_components/flickity/js/drag.js"></script>
-  <script src="../bower_components/flickity/js/tap-listener.js"></script>
   <script src="../bower_components/flickity/js/prev-next-button.js"></script>
   <script src="../bower_components/flickity/js/page-dots.js"></script>
   <script src="../bower_components/flickity/js/player.js"></script>

--- a/test/test-sync.js
+++ b/test/test-sync.js
@@ -2,11 +2,24 @@ test( 'sync', function( assert ) {
   'use strict';
 
   var flktyA = new Flickity( '#sync-a', {
-    sync: '#sync-b'
+    sync: '#sync-b',
+    arrowShape: {
+      x0: 15,
+      x1: 50, y1: 40,
+      x2: 55, y2: 35,
+      x3: 25
+    }
   });
 
   var elemB = document.querySelector('#sync-b');
-  var flktyB = new Flickity( elemB );
+  var flktyB = new Flickity( elemB, {
+    arrowShape: {
+      x0: 15,
+      x1: 50, y1: 40,
+      x2: 55, y2: 35,
+      x3: 25
+    }
+  });
 
   // HACK do async because syncing is async
   var done = assert.async();


### PR DESCRIPTION
Would be nice to use sync together with `arrowShape`.
