### PR TITLE
Bump version to get most recent flickity

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,8 @@
   "description": "Enable sync for Flickity",
   "main": "flickity-sync.js",
   "dependencies": {
-    "flickity": "^2.0.0",
-    "fizzy-ui-utils": "^2.0.0"
+    "flickity": "^2.0.10",
+    "fizzy-ui-utils": "^2.0.5"
   },
   "devDependencies": {
     "qunit": "~1.17.1"

--- a/flickity-sync.js
+++ b/flickity-sync.js
@@ -1,5 +1,5 @@
 /*!
- * Flickity sync v2.0.0
+ * Flickity sync v2.0.1
  * enable sync for Flickity
  */
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "flickity-sync",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Enable sync for Flickity",
   "main": "flickity-sync.js",
   "dependencies": {
-    "flickity": "^2.0.0",
-    "fizzy-ui-utils": "^2.0.0"
+    "flickity": "^2.0.10",
+    "fizzy-ui-utils": "^2.0.5"
   },
   "scripts": {
     "test": "echo \"Open test/index.html in browser\" && exit 1"


### PR DESCRIPTION
bumping the version here so we can get some bug fixes that went in between 2.0.0 and 2.0.10.

tests pass after running `bower i` in:
- chrome stable
- ff stable
- safari 10.1.2
- ie 11 (run on VM via browserstack)